### PR TITLE
Update where ID comes from

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -27,7 +27,7 @@ exports.sourceNodes = async ({ boundActionCreators },
   all.forEach(row => {
     const gatsbyNode = Object.assign({
       // Required Gatsby fields
-      id: `Airtable ${tableName} ${row.fields.Id}`,
+      id: `Airtable ${tableName} ${row.id}`,
       parent: "__SOURCE__",
       children: [],
       internal: {


### PR DESCRIPTION
Hey @kevzettler! Thanks for making this Gatsby plugin! I tried integrating it into my project today and I came across an issue that perhaps this PR can address.

According to the Airtable API, each row will have an `id` defined at the same level as the `fields` attribute within a list of records. My issue was that `row.fields.Id` always returned `undefined` so each airtable node would get overwritten in the Gatsby store. Only the last one in the `forEach` loop to create the nodes would end up in my QraphQL query since they all had the same id, "Airtable Project undefined".

If ID is meant to be the Airtable row Id, it should be a value starting with "rec". Otherwise, I think you would have to have a column in your table labeled "Id".

<img width="645" alt="screen shot 2017-10-26 at 4 58 18 pm" src="https://user-images.githubusercontent.com/5697474/32079189-54fdb1e8-ba6f-11e7-9bc0-bff6d8926477.png">
